### PR TITLE
docs: reorder maintainer/contributor projects and add LWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you are interested in me, please email me:  📫 yankay.com@gmail.com.
 
 🔭 I’m currently working on [DaoCloud](https://www.daocloud.io/en/), ex [EMC](https://en.wikipedia.org/wiki/Dell_EMC), ex [Nanjing University](https://en.wikipedia.org/wiki/Nanjing_University)
 
-😄 Maintainer/contributor across selected projects including [Kubespray](https://github.com/kubernetes-sigs/kubespray), [nerdctl](https://github.com/containerd/nerdctl), [K8sGPT](https://github.com/k8sgpt-ai/k8sgpt), [llm-d](https://github.com/llm-d), [Kubean](https://github.com/kubean-io/kubean), [Spiderpool](https://github.com/spidernet-io/spiderpool), [MatrixHub](https://github.com/matrixhub-ai/matrixhub), and [ClawWork](https://github.com/clawwork-ai/ClawWork)
+😄 Maintainer/contributor across selected projects including [Kubespray](https://github.com/kubernetes-sigs/kubespray), [llm-d](https://github.com/llm-d), [LWS](https://github.com/kubernetes-sigs/lws), [Spiderpool](https://github.com/spidernet-io/spiderpool), [Kubean](https://github.com/kubean-io/kubean), [ClawWork](https://github.com/clawwork-ai/ClawWork), [MatrixHub](https://github.com/matrixhub-ai/matrixhub), [nerdctl](https://github.com/containerd/nerdctl), and [K8sGPT](https://github.com/k8sgpt-ai/k8sgpt)
 
 🌱 Learning and Sharing
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## Hi 👋 I am Kay Yan (颜开)
 
-If you are interested in me, please email me:  📫 yankay.com@gmail.com. 
+If you are interested in me, please email me:  📫 yankay.com@gmail.com.
 
-⚡ Fun fact: **Cloud Native**, **AI/LLM**  
+⚡ Focus: **Cloud Native**, **AI/LLM**  
 
-🔭 I’m currently working on [DaoCloud](https://www.daocloud.io/en/), ex [EMC](https://en.wikipedia.org/wiki/Dell_EMC), ex [Nanjing University](https://en.wikipedia.org/wiki/Nanjing_University)
+🔭 I’m currently working on [DaoCloud](https://www.daocloud.io/en/), ex [EMC](https://en.wikipedia.org/wiki/Dell_EMC), studied at [Nanjing University](https://en.wikipedia.org/wiki/Nanjing_University)
 
 😄 Maintainer/contributor across selected projects including [Kubespray](https://github.com/kubernetes-sigs/kubespray), [llm-d](https://github.com/llm-d), [LWS](https://github.com/kubernetes-sigs/lws), [Spiderpool](https://github.com/spidernet-io/spiderpool), [Kubean](https://github.com/kubean-io/kubean), [ClawWork](https://github.com/clawwork-ai/ClawWork), [MatrixHub](https://github.com/matrixhub-ai/matrixhub), [nerdctl](https://github.com/containerd/nerdctl), and [K8sGPT](https://github.com/k8sgpt-ai/k8sgpt)
 
@@ -14,30 +14,25 @@ Recent Highlights:
 - **2026 KubeCon EU**: [Tutorial: KV-Cache Wins You Can Feel: Building AI-Aware LLM Routing on Kubernetes](https://kccnceu2026.sched.com/event/2CW5y/tutorial-kv-cache-wins-you-can-feel-building-ai-aware-llm-routing-on-kubernetes-tyler-michael-smith-red-hat-kay-yan-daocloud-vita-bortnikov-michal-malka-maroon-ayoub-ibm)
 - **2025 KubeCon Japan**: [Sailing Multi-host Inference for LLM on Kubernetes](https://kccncjpn2025.sched.com/event/1x6zY/sailing-multi-host-inference-for-llm-on-kubernetes-kay-yan-daocloud)
 - **2025 KubeCon China**: [AI-Powered Kubernetes Diagnostics With K8sGPT](https://kccncchn2025.sched.com/event/1x5iR/cl-lightning-talk-ai-powered-kubernetes-diagnostics-with-k8sgpt-kay-yan-daocloud)
-- **2025 KubeCon China**: [Building Custom GPU Clusters at Scale][def]
+- **2025 KubeCon China**: [Building Custom GPU Clusters at Scale](https://kccncchn2025.sched.com/event/1x5hZ/building-custom-gpu-clusters-at-scale-using-kubespray-to-create-high-performance-ai-infrastructure-kay-yan-daocloud-rong-zhang-vivo)
 
 See [more slides](slides/README.md)
 
-🏆 Honors：
+🏆 Honors:
 
-* [2023 "Top Ten Outstanding Software Engineers" - China Electronic Information Industry Federation](https://baijiahao.baidu.com/s?id=1776345995076640356&wfr=spider&for=pc)
-* [2019 Forbes List of China’s 30 elites under 30 years old - Forbes China](https://www.forbeschina.com/lists/1725)
-* 2012 EMC Global Innovation Showcase CTO Award
-* 2007 Top 10 in [ACM/ICPC](https://en.wikipedia.org/wiki/International_Collegiate_Programming_Contest) Asian Regional Competition Nanjing Division
+- [2023 "Top Ten Outstanding Software Engineers" - China Electronic Information Industry Federation](https://baijiahao.baidu.com/s?id=1776345995076640356&wfr=spider&for=pc)
+- [2019 Forbes List of China’s 30 elites under 30 years old - Forbes China](https://www.forbeschina.com/lists/1725)
+- 2012 EMC Global Innovation Showcase CTO Award
+- 2007 Top 10 in [ACM/ICPC](https://en.wikipedia.org/wiki/International_Collegiate_Programming_Contest) Asian Regional Competition Nanjing Division
 
 ![Metrics](https://raw.githubusercontent.com/yankay/yankay/metrics-renders/github-metrics.svg)
 
 ![github contribution grid snake animation](https://raw.githubusercontent.com/yankay/yankay/output/github-contribution-grid-snake.svg)
 
-🛸 Badges：
+🛸 Badges:
 
 <img src="https://images.credly.com/images/f09ecd0d-af5b-4933-9919-5db84511eae4/blob" height="100"/><img src="https://images.credly.com/images/56cff060-8267-4cc5-a6b0-b35141b3beeb/blob" height="100"/><img src="https://images.credly.com/images/184b21c5-3f6c-49d7-97d7-9087d1676b99/blob" height="100"/><img src="https://images.credly.com/images/43195a73-9ee6-40c7-bd75-eae8515ac836/blob" height="100"/><img src="https://images.credly.com/images/67a3d9a6-e07c-443e-9ac3-e72067b407d8/blob" height="100"/><img src="https://images.credly.com/images/ebedf05f-3b04-4163-a147-9e469bdaddbf/blob" height="100"/><img src="https://images.credly.com/images/7452e181-d092-4b92-934f-dfc16d9061e9/image.png" height="100"/><img src="https://images.credly.com/images/659b3a27-9b9d-4a19-8548-b686d3563c2b/image.png" height="100"/><img src="https://images.credly.com/images/8ce9ab71-6745-4b22-98f2-99f3b12a3aa6/image.png" height="100"/><img src="https://images.credly.com/images/23f11122-3a84-4796-9854-6cbdae8a73bf/image.png" height="100"/><img src="https://images.credly.com/images/8b8ed108-e77d-4396-ac59-2504583b9d54/cka_from_cncfsite__281_29.png" height="100"/><img src="https://images.credly.com/images/9945dfcb-1cca-4529-85e6-db1be3782210/kubernetes-security-specialist-logo2.png" height="100"/><img src="https://images.credly.com/images/cc8adc83-1dc6-4d57-8e20-22171247e052/blob" height="100"/>
 
 📷 Photo:
 
 <img src="./pictures/self.jpg" alt="self" height="140"><img src="./pictures/together.jpg" alt="together" height="140"><img src="./pictures/with-linus.jpg" alt="with-linus" height="140">
-
-
-
-
-[def]: https://kccncchn2025.sched.com/event/1x5hZ/building-custom-gpu-clusters-at-scale-using-kubespray-to-create-high-performance-ai-infrastructure-kay-yan-daocloud-rong-zhang-vivo


### PR DESCRIPTION
## Summary
- Reorder the maintainer/contributor project list by prominence and involvement
- Add LWS (kubernetes-sigs/lws), where I now serve as an Approver
- Move nerdctl and K8sGPT toward the end (contributor-level involvement)

## Test plan
- [ ] Confirm the rendered README project list reads in the intended order
- [ ] Verify the LWS link points to https://github.com/kubernetes-sigs/lws